### PR TITLE
created WaitingListService, WaitingListEntry, WaitingListRepository, and unit tests for them

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-Release The Kraken

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />

--- a/app/src/main/java/com/example/releasethekraken/MainActivity.java
+++ b/app/src/main/java/com/example/releasethekraken/MainActivity.java
@@ -1,12 +1,18 @@
 package com.example.releasethekraken;
 
 import android.os.Bundle;
+import android.util.Log;
 
 import androidx.activity.EdgeToEdge;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+
+import com.example.releasethekraken.controller.WaitingListService;
+import com.example.releasethekraken.model.WaitingListRepository;
+import com.example.releasethekraken.model.Event;
+
 
 public class MainActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/example/releasethekraken/controller/WaitingListService.java
+++ b/app/src/main/java/com/example/releasethekraken/controller/WaitingListService.java
@@ -1,4 +1,103 @@
 package com.example.releasethekraken.controller;
 
-public class WaitingListService {
+//other classes this uses
+import com.example.releasethekraken.model.WaitingListRepository;
+import com.example.releasethekraken.model.WaitingListEntry;
+import com.example.releasethekraken.model.Event;
+
+//implements rules for the joining of the waiting list
+//validate registration window
+//prevent duplicates
+//store in Firestore
+//no UI
+
+public class  WaitingListService {
+
+    //repo that stores and retrieves waiting list data entries from firestore
+    private final WaitingListRepository waitingListRepository;
+
+    //creates a WaitingListService with the repo dependency
+    //this makes it easy to swap repos in the future (firestore)
+    public WaitingListService(WaitingListRepository waitingListRepository) {
+        this.waitingListRepository = waitingListRepository;
+    }
+
+    //possible outcomes of attempting to join the waiting list
+    //used enum to make it simple for the View to show correct message,
+    // can also add more outcomes if needed
+    public enum JoinResult {
+        SUCCESS,
+        REGISTRATION_CLOSED,
+        DUPLICATE_ENTRY,
+        INVALID_INPUT
+
+    }
+
+    /**
+     * checks whether the current time is inside the events registration period
+     *
+     * @param event The event being joined
+     * @param nowMillis Current time in milliseconds since epoch
+     * @return true if registration is open, false otherwise
+     */
+    public boolean isRegistrationOpen(Event event, long nowMillis) {
+
+        // registration is open if now is between start and end inclusive
+        if (event == null) {
+            return false;
+        }
+
+        return nowMillis >= event.getRegistrationStartMillis()
+                && nowMillis <= event.getRegistrationEndMillis();
+    }
+
+    /**
+     * join the waiting list for an event US 01.01.01
+     * this method enforces acceptance criteria
+     *  - Entrant can join during registration period
+     *  - Duplicate entries prevented
+     *  - Entry is stored via WaitingListRepository using Firestore
+     *
+     * @param event event the entrant is trying to join
+     * @param entrantId  entrant/device identifier
+     * @return JoinResult indicating what happened
+     */
+    public JoinResult joinWaitingList(Event event, String entrantId) {
+
+        //validation to avoid null or empty values causing crashes
+        if (event == null || entrantId == null || entrantId.trim().isEmpty()) {
+            return JoinResult.INVALID_INPUT;
+        }
+
+        long nowMillis = System.currentTimeMillis();
+
+        // 1. validate registration window
+        if (!isRegistrationOpen(event, nowMillis)) {
+            return JoinResult.REGISTRATION_CLOSED;
+        }
+
+        // 2. prevent duplicates
+        // NOTE: This is synchronous right now because no Firestore
+        // later with Firestore, this will likely become asynchronous tbd
+        boolean alreadyWaiting = waitingListRepository.isEntrantAlreadyWaiting(
+                event.getEventId(),
+                entrantId
+        );
+
+        if (alreadyWaiting) {
+            return JoinResult.DUPLICATE_ENTRY;
+        }
+
+        // 3. create the waiting list entry with exact join time
+        WaitingListEntry entry = new WaitingListEntry(
+                event.getEventId(),
+                entrantId,
+                nowMillis
+        );
+
+        // 4. store it repository will later store in Firestore
+        waitingListRepository.addToWaitingList(entry);
+
+        return JoinResult.SUCCESS;
+    }
 }

--- a/app/src/main/java/com/example/releasethekraken/model/WaitingListEntry.java
+++ b/app/src/main/java/com/example/releasethekraken/model/WaitingListEntry.java
@@ -1,4 +1,44 @@
 package com.example.releasethekraken.model;
 
+//model class to represent one entrants entry on a event waiting list
+//this is used for joining wait list and leave waiting list tickets ( US 01.01.01 and  US 01.01.02)
+//this class holds data only, no UI or Firebase code added atm.
+//
+
+
 public class WaitingListEntry {
+
+    //the event this entry belongs to
+    private final String eventId;
+
+    //the entrant ID that joined the waiting list
+    private final String entrantId;
+
+    //when the entrant joined the waiting list in milliseconds
+    private final long joinedAtMillis;
+
+    /**
+     * Create a waiting list entry
+     *
+     * @param eventId        event identifier
+     * @param entrantId      entrant identifier could be device id or user id
+     * @param joinedAtMillis time joined
+     */
+    public WaitingListEntry(String eventId, String entrantId, long joinedAtMillis) {
+        this.eventId = eventId;
+        this.entrantId = entrantId;
+        this.joinedAtMillis = joinedAtMillis;
+    }
+
+    public String getEventId() { //return event id
+        return eventId;
+    }
+
+    public String getEntrantId() { //return entrant id
+        return entrantId;
+    }
+
+    public long getJoinedAtMillis() { //return time joined
+        return joinedAtMillis;
+    }
 }

--- a/app/src/main/java/com/example/releasethekraken/model/WaitingListRepository.java
+++ b/app/src/main/java/com/example/releasethekraken/model/WaitingListRepository.java
@@ -1,4 +1,22 @@
 package com.example.releasethekraken.model;
 
+//responsible for saving and retrieving waiting list entries data
+//this is in the model package
+//no UI logic
+//will talk to Firebase for data
+
+// TODO:**FIRESTORE METHOD STILL NEEDS TO BE ADDED IN THE COMMENTS BELOW IN THE CODE**
 public class WaitingListRepository {
+
+    //returns true if the entrant is already on the waiting list
+    public boolean isEntrantAlreadyWaiting(String eventId, String entrantId) {
+        // TODO: replace with Firestore query
+        return false;
+    }
+
+    //saves a new waiting list entry for event as data in Firestore
+    public void addToWaitingList(WaitingListEntry entry) {
+        // TODO: replace with Firestore write
+    }
+
 }

--- a/app/src/test/java/com/example/releasethekraken/WaitingListServiceTest.java
+++ b/app/src/test/java/com/example/releasethekraken/WaitingListServiceTest.java
@@ -1,0 +1,90 @@
+package com.example.releasethekraken;
+
+import com.example.releasethekraken.controller.WaitingListService;
+import com.example.releasethekraken.model.Event;
+import com.example.releasethekraken.model.WaitingListEntry;
+import com.example.releasethekraken.model.WaitingListRepository;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+public class WaitingListServiceTest {
+
+    //fake repo so we can control behavior and inspect what gets saved
+    static class FakeWaitingListRepository extends WaitingListRepository {
+        boolean alreadyWaiting = false;
+        WaitingListEntry savedEntry = null;
+
+        @Override
+        public boolean isEntrantAlreadyWaiting(String eventId, String entrantId) {
+            return alreadyWaiting;
+        }
+
+        @Override
+        public void addToWaitingList(WaitingListEntry entry) {
+            savedEntry = entry;
+        }
+    }
+
+    @Test
+    public void joinWaitingList_invalidInput_returnsInvalidInput() {
+        FakeWaitingListRepository repo = new FakeWaitingListRepository();
+        WaitingListService service = new WaitingListService(repo);
+
+        WaitingListService.JoinResult result = service.joinWaitingList(null, "device123");
+        assertEquals(WaitingListService.JoinResult.INVALID_INPUT, result);
+
+        WaitingListService.JoinResult result2 = service.joinWaitingList(makeOpenEvent(), "   ");
+        assertEquals(WaitingListService.JoinResult.INVALID_INPUT, result2);
+    }
+
+    @Test
+    public void joinWaitingList_registrationClosed_returnsRegistrationClosed() {
+        FakeWaitingListRepository repo = new FakeWaitingListRepository();
+        WaitingListService service = new WaitingListService(repo);
+
+        long now = System.currentTimeMillis();
+        Event closedEvent = new Event("event123", now - 200000, now - 100000); // ended in the past
+
+        WaitingListService.JoinResult result = service.joinWaitingList(closedEvent, "device123");
+        assertEquals(WaitingListService.JoinResult.REGISTRATION_CLOSED, result);
+        assertNull(repo.savedEntry); // nothing saved
+    }
+
+    @Test
+    public void joinWaitingList_duplicate_returnsDuplicateEntry() {
+        FakeWaitingListRepository repo = new FakeWaitingListRepository();
+        repo.alreadyWaiting = true;
+
+        WaitingListService service = new WaitingListService(repo);
+
+        WaitingListService.JoinResult result = service.joinWaitingList(makeOpenEvent(), "device123");
+        assertEquals(WaitingListService.JoinResult.DUPLICATE_ENTRY, result);
+        assertNull(repo.savedEntry); // nothing saved
+    }
+
+    @Test
+    public void joinWaitingList_success_savesEntryAndReturnsSuccess() {
+        FakeWaitingListRepository repo = new FakeWaitingListRepository();
+        repo.alreadyWaiting = false;
+
+        WaitingListService service = new WaitingListService(repo);
+
+        Event event = makeOpenEvent();
+        String entrantId = "device123";
+
+        WaitingListService.JoinResult result = service.joinWaitingList(event, entrantId);
+        assertEquals(WaitingListService.JoinResult.SUCCESS, result);
+
+        // verify it saved something
+        assertNotNull(repo.savedEntry);
+        assertEquals(event.getEventId(), repo.savedEntry.getEventId());
+        assertEquals(entrantId, repo.savedEntry.getEntrantId());
+        assertTrue(repo.savedEntry.getJoinedAtMillis() > 0);    }
+
+    // helper: registration window definitely open now
+    private Event makeOpenEvent() {
+        long now = System.currentTimeMillis();
+        return new Event("event123", now - 1000000, now + 1000000);
+    }
+}


### PR DESCRIPTION
- The WaitingListEntry class represents a single entrant joining the waiting list and records the event ID, entrant ID, and the exact time the entrant joined. 

- The WaitingListRepository class acts as the data layer responsible for storing and retrieving waiting list entries, and will later handle communication with Firestore. 

- The WaitingListService class acts like the controller for joining the waiting list, including validating the registration window, preventing duplicate entries, and creating a new waiting list entry when the conditions are met. It has 4 test cases it for it too.

- #2 