### PR TITLE
added leaving wait list logic, database will be done when we have firbase

### DIFF
--- a/app/src/main/java/com/example/releasethekraken/controller/WaitingListService.java
+++ b/app/src/main/java/com/example/releasethekraken/controller/WaitingListService.java
@@ -11,7 +11,7 @@ import com.example.releasethekraken.model.Event;
 //store in Firestore
 //no UI
 
-public class  WaitingListService {
+public class WaitingListService {
 
     //repo that stores and retrieves waiting list data entries from firestore
     private final WaitingListRepository waitingListRepository;
@@ -29,8 +29,51 @@ public class  WaitingListService {
         SUCCESS,
         REGISTRATION_CLOSED,
         DUPLICATE_ENTRY,
-        INVALID_INPUT
+        INVALID_INPUT,
+    }
 
+    //possible outcomes of attempting to leave the waiting list
+    //used enum to make it simple for the View to show correct message,
+    public enum LeaveResult {
+        SUCCESS,
+        NOT_ON_WAITING_LIST,
+        INVALID_INPUT,
+    }
+
+    /**
+     * leave the waiting list for an event US 01.01.02
+     *  - Entrant can leave the waiting list
+     *  - Entrant is removed from the waiting list
+     *
+     * @param event event the entrant is trying to leave
+     * @param entrantId entrant/device identifier
+     * @return LeaveResult indicating what happened
+     */
+
+    public LeaveResult leaveWaitingList(Event event, String entrantId) {
+
+        //to avoid null or empty values causing crashes
+        if (event == null || entrantId == null || entrantId.trim().isEmpty()) {
+            return LeaveResult.INVALID_INPUT;
+        }
+
+        // check if entrant is actually on the waiting list
+        boolean alreadyWaiting = waitingListRepository.isEntrantAlreadyWaiting(
+                event.getEventId(),
+                entrantId
+        );
+
+        if (!alreadyWaiting) {
+            return LeaveResult.NOT_ON_WAITING_LIST;
+        }
+
+        // remove entrant from waiting list
+        waitingListRepository.removeFromWaitingList(
+                event.getEventId(),
+                entrantId
+        );
+
+        return LeaveResult.SUCCESS;
     }
 
     /**

--- a/app/src/main/java/com/example/releasethekraken/model/WaitingListRepository.java
+++ b/app/src/main/java/com/example/releasethekraken/model/WaitingListRepository.java
@@ -19,4 +19,10 @@ public class WaitingListRepository {
         // TODO: replace with Firestore write
     }
 
+    //removes a waiting list entry for event as data in Firestore
+    public void removeFromWaitingList(String eventId, String entrantId) {
+        // TODO: replace with Firestore write
+
+    }
+
 }

--- a/app/src/test/java/com/example/releasethekraken/WaitingListServiceTest.java
+++ b/app/src/test/java/com/example/releasethekraken/WaitingListServiceTest.java
@@ -13,6 +13,7 @@ public class WaitingListServiceTest {
     //fake repo so we can control behavior and inspect what gets saved
     static class FakeWaitingListRepository extends WaitingListRepository {
         boolean alreadyWaiting = false;
+        boolean removed = false;
         WaitingListEntry savedEntry = null;
 
         @Override
@@ -23,6 +24,11 @@ public class WaitingListServiceTest {
         @Override
         public void addToWaitingList(WaitingListEntry entry) {
             savedEntry = entry;
+        }
+
+        @Override
+        public void removeFromWaitingList(String eventId, String entrantId) {
+            removed = true;
         }
     }
 
@@ -87,4 +93,42 @@ public class WaitingListServiceTest {
         long now = System.currentTimeMillis();
         return new Event("event123", now - 1000000, now + 1000000);
     }
+
+    @Test
+    public void leaveWaitingList_invalidInput_returnsInvalidInput() {
+        FakeWaitingListRepository repo = new FakeWaitingListRepository();
+        WaitingListService service = new WaitingListService(repo);
+
+        WaitingListService.LeaveResult result = service.leaveWaitingList(null, "device123");
+        assertEquals(WaitingListService.LeaveResult.INVALID_INPUT, result);
+
+        WaitingListService.LeaveResult result2 = service.leaveWaitingList(makeOpenEvent(), "   ");
+        assertEquals(WaitingListService.LeaveResult.INVALID_INPUT, result2);
+    }
+
+    @Test
+    public void leaveWaitingList_notOnWaitingList_returnsNotOnWaitingList() {
+        FakeWaitingListRepository repo = new FakeWaitingListRepository();
+        repo.alreadyWaiting = false;
+
+        WaitingListService service = new WaitingListService(repo);
+
+        WaitingListService.LeaveResult result = service.leaveWaitingList(makeOpenEvent(), "device123");
+        assertEquals(WaitingListService.LeaveResult.NOT_ON_WAITING_LIST, result);
+        assertFalse(repo.removed);
+    }
+
+    @Test
+    public void leaveWaitingList_success_removesEntrant() {
+        FakeWaitingListRepository repo = new FakeWaitingListRepository();
+        repo.alreadyWaiting = true;
+
+        WaitingListService service = new WaitingListService(repo);
+
+        WaitingListService.LeaveResult result = service.leaveWaitingList(makeOpenEvent(), "device123");
+        assertEquals(WaitingListService.LeaveResult.SUCCESS, result);
+        assertTrue(repo.removed);
+    }
+
+
 }


### PR DESCRIPTION
Implements the leave waiting list logic for entrants. Was just built on top of US.01.01.01 since we just need to remove users from the waitlist. #3  


Features:
- input validation
- checks whether entrant is on the waiting list
- prevents invalid removal
- removes entrant from waiting list through repository which is database.

Notes:
Firestore integration will be implemented later in the repository later when we have it.