### PR TITLE
can now create an event, and waitlist it as well

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-03-12T04:59:11.346718Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\kirin\.android\avd\Medium_Phone.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/src/main/java/com/example/releasethekraken/model/Event.java
+++ b/app/src/main/java/com/example/releasethekraken/model/Event.java
@@ -1,5 +1,3 @@
-//this tells java where the class lives in the project
-//package models;
 package com.example.releasethekraken.model;
 
 //event class
@@ -16,20 +14,27 @@ public class Event {
     //could be a firestore document ID or generated ID
     private final String eventId;
 
+    private final String title; //title of the event
+    private final String description; //description of the event
+
     private final long registrationStartMillis; //time in milliseconds when registration starts for the event
     private final long registrationEndMillis; //time in milliseconds when registration ends for the event
-
 
     /**
      * Constructor for creating a new Event object.
      *
      * @param eventId unique ID for the event
+     * @param title title of the event
+     * @param description description of the event
      * @param registrationStartMillis Time when registration starts
      * @param registrationEndMillis Time when registration ends
      */
-    public Event(String eventId, long registrationStartMillis, long registrationEndMillis) {
+    public Event(String eventId, String title, String description,
+                 long registrationStartMillis, long registrationEndMillis) {
         //assign constructor parameters to class fields
         this.eventId = eventId;
+        this.title = title;
+        this.description = description;
         this.registrationStartMillis = registrationStartMillis;
         this.registrationEndMillis = registrationEndMillis;
     }
@@ -38,10 +43,22 @@ public class Event {
     public String getEventId() {
         return eventId;
     }
+
+    //returns event title
+    public String getTitle() {
+        return title;
+    }
+
+    //returns event description
+    public String getDescription() {
+        return description;
+    }
+
     //returns registration start time
     public long getRegistrationStartMillis() {
         return registrationStartMillis;
     }
+
     //returns registration end time
     public long getRegistrationEndMillis() {
         return registrationEndMillis;

--- a/app/src/main/java/com/example/releasethekraken/model/EventRepository.java
+++ b/app/src/main/java/com/example/releasethekraken/model/EventRepository.java
@@ -4,7 +4,9 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Responsible for loading events from Firestore.
@@ -31,6 +33,27 @@ public class EventRepository {
         void onError(Exception e);
     }
 
+    public interface CompletionCallback {
+        void onSuccess();
+        void onError(Exception e);
+    }
+
+    //creates a new event in Firestore
+    public void createEvent(Event event, CompletionCallback callback) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("eventId", event.getEventId());
+        data.put("title", event.getTitle());
+        data.put("description", event.getDescription());
+        data.put("registrationStartMillis", event.getRegistrationStartMillis());
+        data.put("registrationEndMillis", event.getRegistrationEndMillis());
+
+        db.collection("events")
+                .document(event.getEventId())
+                .set(data)
+                .addOnSuccessListener(unused -> callback.onSuccess())
+                .addOnFailureListener(callback::onError);
+    }
+
     //gets one event by its Firestore document ID
     public void getEventById(String eventId, EventCallback callback) {
         db.collection("events")
@@ -42,9 +65,17 @@ public class EventRepository {
                         return;
                     }
 
+                    String title = documentSnapshot.getString("title");
+                    String description = documentSnapshot.getString("description");
                     Long registrationStartMillis = documentSnapshot.getLong("registrationStartMillis");
                     Long registrationEndMillis = documentSnapshot.getLong("registrationEndMillis");
 
+                    if (title == null) {
+                        title = "";
+                    }
+                    if (description == null) {
+                        description = "";
+                    }
                     if (registrationStartMillis == null) {
                         registrationStartMillis = 0L;
                     }
@@ -54,6 +85,8 @@ public class EventRepository {
 
                     Event event = new Event(
                             documentSnapshot.getId(),
+                            title,
+                            description,
                             registrationStartMillis,
                             registrationEndMillis
                     );
@@ -64,7 +97,6 @@ public class EventRepository {
     }
 
     //gets all events from Firestore
-
     public void getAllEvents(EventsCallback callback) {
         db.collection("events")
                 .get()
@@ -72,9 +104,17 @@ public class EventRepository {
                     List<Event> events = new ArrayList<>();
 
                     for (QueryDocumentSnapshot document : queryDocumentSnapshots) {
+                        String title = document.getString("title");
+                        String description = document.getString("description");
                         Long registrationStartMillis = document.getLong("registrationStartMillis");
                         Long registrationEndMillis = document.getLong("registrationEndMillis");
 
+                        if (title == null) {
+                            title = "";
+                        }
+                        if (description == null) {
+                            description = "";
+                        }
                         if (registrationStartMillis == null) {
                             registrationStartMillis = 0L;
                         }
@@ -84,6 +124,8 @@ public class EventRepository {
 
                         Event event = new Event(
                                 document.getId(),
+                                title,
+                                description,
                                 registrationStartMillis,
                                 registrationEndMillis
                         );

--- a/app/src/main/java/com/example/releasethekraken/view/BrowseEventsFragment.java
+++ b/app/src/main/java/com/example/releasethekraken/view/BrowseEventsFragment.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
@@ -16,13 +17,20 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.releasethekraken.MainActivity;
 import com.example.releasethekraken.R;
-import com.example.releasethekraken.placeholder.PlaceholderContent;
+import com.example.releasethekraken.model.Event;
+import com.example.releasethekraken.model.EventRepository;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class BrowseEventsFragment extends Fragment {
 
     private static final String ARG_COLUMN_COUNT = "column-count";
     private int mColumnCount = 2;
     private boolean yourEvents;
+
+    private final List<Event> eventList = new ArrayList<>();
+    private MyItemRecyclerViewAdapter adapter;
 
     public BrowseEventsFragment() { }
 
@@ -67,28 +75,29 @@ public class BrowseEventsFragment extends Fragment {
             recyclerView.setLayoutManager(new GridLayoutManager(getContext(), mColumnCount));
         }
 
-        // TODO: Change the adapter to the events viewing adapter
-        recyclerView.setAdapter(
-                new MyItemRecyclerViewAdapter(PlaceholderContent.ITEMS, item -> {
-                    Bundle args = new Bundle();
-                    args.putString("eventId", item.id);
+        adapter = new MyItemRecyclerViewAdapter(eventList, event -> {
+            Bundle args = new Bundle();
+            args.putString("eventId", event.getEventId());
 
-                    Navigation.findNavController(view)
-                            .navigate(R.id.action_browseEventsFragment_to_eventDetailsFragment, args);
-                })
-        );
+            Navigation.findNavController(view)
+                    .navigate(R.id.action_browseEventsFragment_to_eventDetailsFragment, args);
+        });
 
+        recyclerView.setAdapter(adapter);
+
+        loadEvents();
 
         Button createEventButton = view.findViewById(R.id.create_event_button);
         // Hide the create events button if we aren't in your Events
-        if (!yourEvents) {createEventButton.setVisibility(View.GONE);}
+        if (!yourEvents) {
+            createEventButton.setVisibility(View.GONE);
+        }
 
         // Navigate to Create Events
-        createEventButton
-                .setOnClickListener(v ->
-                        Navigation.findNavController(v)
-                                .navigate(R.id.action_browseEventsFragment_to_createEventFragment)
-                );
+        createEventButton.setOnClickListener(v ->
+                Navigation.findNavController(v)
+                        .navigate(R.id.action_browseEventsFragment_to_createEventFragment)
+        );
 
         // Return to Main Menu from Toolbar
         view.findViewById(R.id.home_toolbar_button)
@@ -115,7 +124,7 @@ public class BrowseEventsFragment extends Fragment {
         // Navigate to Event Details as an Organizer
         view.findViewById(R.id.dummy_organizer_button).setOnClickListener(v -> {
             Bundle bundle = new Bundle();
-            bundle.putString("UserType", MainActivity.UserType.ORGANIZER.name()); // Using this argument to determine what should be displayed
+            bundle.putString("UserType", MainActivity.UserType.ORGANIZER.name());
 
             Navigation.findNavController(v)
                     .navigate(R.id.action_mainMenuFragment_to_browseEventsFragment, bundle);
@@ -125,12 +134,34 @@ public class BrowseEventsFragment extends Fragment {
         // Navigate to Event Details as an Entrant
         view.findViewById(R.id.dummy_entrant_button).setOnClickListener(v -> {
             Bundle bundle = new Bundle();
-            bundle.putString("UserType", MainActivity.UserType.ENTRANT.name()); // Using this argument to determine what should be displayed
+            bundle.putString("UserType", MainActivity.UserType.ENTRANT.name());
 
             Navigation.findNavController(v)
                     .navigate(R.id.action_mainMenuFragment_to_browseEventsFragment, bundle);
         });
 
         return view;
+    }
+
+    private void loadEvents() {
+        EventRepository repository = new EventRepository();
+
+        repository.getAllEvents(new EventRepository.EventsCallback() {
+            @Override
+            public void onSuccess(List<Event> events) {
+                eventList.clear();
+                eventList.addAll(events);
+                adapter.notifyDataSetChanged();
+            }
+
+            @Override
+            public void onError(Exception e) {
+                if (getContext() != null) {
+                    Toast.makeText(getContext(),
+                            "Failed to load events: " + e.getMessage(),
+                            Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
     }
 }

--- a/app/src/main/java/com/example/releasethekraken/view/CreateEventFragment.java
+++ b/app/src/main/java/com/example/releasethekraken/view/CreateEventFragment.java
@@ -1,6 +1,11 @@
 package com.example.releasethekraken.view;
 
 import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -8,15 +13,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
 
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-
 import com.example.releasethekraken.R;
 import com.example.releasethekraken.databinding.FragmentCreateEventBinding;
-import com.example.releasethekraken.databinding.FragmentViewProfileBinding;
-import com.example.releasethekraken.model.Profile;
-import com.example.releasethekraken.repository.ProfileRepository;
+import com.example.releasethekraken.model.Event;
+import com.example.releasethekraken.model.EventRepository;
 
 public class CreateEventFragment extends Fragment {
 
@@ -44,12 +44,102 @@ public class CreateEventFragment extends Fragment {
             }
         }
 
-        // Navigate back to main menu
+        // Navigate back to browse events
         binding.cancelEventCreation.setOnClickListener(v ->
                 Navigation.findNavController(v)
                         .navigate(R.id.action_createEventFragment_to_browseEventsFragment)
         );
+
+        // Create event and save to Firestore
+        binding.createEvent.setOnClickListener(v -> createEventAndSave());
     }
 
+    private void createEventAndSave() {
+        String title = binding.nameEventCreate.getText().toString().trim();
+        String description = binding.eventDescriptionText.getText().toString().trim();
+        String startText = binding.registrationStartDate.getText().toString().trim();
+        String endText = binding.registrationEndDate.getText().toString().trim();
 
+        if (TextUtils.isEmpty(title) || TextUtils.isEmpty(description)
+                || TextUtils.isEmpty(startText) || TextUtils.isEmpty(endText)) {
+            Toast.makeText(getContext(), "Please fill in all required fields", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        long registrationStartMillis;
+        long registrationEndMillis;
+
+        try {
+            java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("dd/MM/yyyy", java.util.Locale.getDefault());
+            sdf.setLenient(false);
+
+            java.util.Date startDate = sdf.parse(startText);
+            java.util.Date endDate = sdf.parse(endText);
+
+            if (startDate == null || endDate == null) {
+                Toast.makeText(getContext(), "Invalid date format", Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            registrationStartMillis = startDate.getTime();
+            registrationEndMillis = endDate.getTime();
+        } catch (Exception e) {
+            Toast.makeText(getContext(),
+                    "Enter dates as dd/MM/yyyy",
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (registrationEndMillis < registrationStartMillis) {
+            Toast.makeText(getContext(),
+                    "Registration end must be after registration start",
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        String eventId = title.replaceAll("\\s+", "_").toLowerCase();
+
+        Event event = new Event(
+                eventId,
+                title,
+                description,
+                registrationStartMillis,
+                registrationEndMillis
+        );
+
+        binding.loading.setVisibility(View.VISIBLE);
+        binding.createEvent.setEnabled(false);
+
+        EventRepository repository = new EventRepository();
+        repository.createEvent(event, new EventRepository.CompletionCallback() {
+            @Override
+            public void onSuccess() {
+                if (!isAdded()) {
+                    return;
+                }
+
+                binding.loading.setVisibility(View.GONE);
+                binding.createEvent.setEnabled(true);
+
+                Toast.makeText(getContext(), "Event created successfully", Toast.LENGTH_SHORT).show();
+
+                Navigation.findNavController(requireView())
+                        .navigate(R.id.action_createEventFragment_to_browseEventsFragment);
+            }
+
+            @Override
+            public void onError(Exception e) {
+                if (!isAdded()) {
+                    return;
+                }
+
+                binding.loading.setVisibility(View.GONE);
+                binding.createEvent.setEnabled(true);
+
+                Toast.makeText(getContext(),
+                        "Failed to create event: " + e.getMessage(),
+                        Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
 }

--- a/app/src/main/java/com/example/releasethekraken/view/EventDetailsFragment.java
+++ b/app/src/main/java/com/example/releasethekraken/view/EventDetailsFragment.java
@@ -16,6 +16,7 @@ import androidx.fragment.app.Fragment;
 import com.example.releasethekraken.R;
 import com.example.releasethekraken.controller.WaitingListService;
 import com.example.releasethekraken.model.Event;
+import com.example.releasethekraken.model.EventRepository;
 import com.example.releasethekraken.model.WaitingListRepository;
 
 //fragment that shows the details for one event and allows the entrant
@@ -33,6 +34,7 @@ public class EventDetailsFragment extends Fragment {
     private Button joinWaitingListButton;
 
     private WaitingListService waitingListService;
+    private EventRepository eventRepository;
     private Event currentEvent;
 
     public EventDetailsFragment() {
@@ -57,6 +59,7 @@ public class EventDetailsFragment extends Fragment {
 
         WaitingListRepository waitingListRepository = new WaitingListRepository();
         waitingListService = new WaitingListService(waitingListRepository);
+        eventRepository = new EventRepository();
     }
 
     @Override
@@ -103,31 +106,35 @@ public class EventDetailsFragment extends Fragment {
         });
     }
 
-    //Temporary event loader
-    //Later, replace this with EventRepository.getEventById(eventId, ...)
+    //load real event details from Firestore
     private void loadEventDetails() {
         if (eventId == null || eventId.trim().isEmpty()) {
             Toast.makeText(requireContext(), "Missing event ID", Toast.LENGTH_SHORT).show();
             return;
         }
 
-        long now = System.currentTimeMillis();
+        eventRepository.getEventById(eventId, new EventRepository.EventCallback() {
+            @Override
+            public void onSuccess(Event event) {
+                currentEvent = event;
+                bindEventToViews();
+            }
 
-        // Temporary hardcoded event so the screen works end-to-end
-        currentEvent = new Event(
-                eventId,
-                now - 60_000,
-                now + 3_600_000
-        );
-
-        bindEventToViews();
+            @Override
+            public void onError(Exception e) {
+                if (isAdded()) {
+                    Toast.makeText(requireContext(),
+                            "Failed to load event: " + e.getMessage(),
+                            Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
     }
 
     //displays the event details on screen
-
     private void bindEventToViews() {
-        titleTextView.setText("Event " + currentEvent.getEventId());
-        descriptionTextView.setText("This is a placeholder event description.");
+        titleTextView.setText(currentEvent.getTitle());
+        descriptionTextView.setText(currentEvent.getDescription());
         registrationStartTextView.setText("Registration opens: "
                 + formatMillis(currentEvent.getRegistrationStartMillis()));
         registrationEndTextView.setText("Registration closes: "
@@ -169,7 +176,6 @@ public class EventDetailsFragment extends Fragment {
 
     //Temporary entrant ID for testing.
     //replace later with the real profile/device/user ID
-
     private String getEntrantId() {
         return "testEntrant001";
     }

--- a/app/src/main/java/com/example/releasethekraken/view/MyItemRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/releasethekraken/view/MyItemRecyclerViewAdapter.java
@@ -7,21 +7,21 @@ import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import com.example.releasethekraken.databinding.ItemEventBinding;
-import com.example.releasethekraken.placeholder.PlaceholderContent.PlaceholderItem;
+import com.example.releasethekraken.model.Event;
 
 import java.util.List;
 
 public class MyItemRecyclerViewAdapter
         extends RecyclerView.Adapter<MyItemRecyclerViewAdapter.ViewHolder> {
 
-    private final List<PlaceholderItem> mValues;
+    private final List<Event> mValues;
     private final OnEventClickListener listener;
 
     public interface OnEventClickListener {
-        void onEventClick(PlaceholderItem item);
+        void onEventClick(Event event);
     }
 
-    public MyItemRecyclerViewAdapter(List<PlaceholderItem> items, OnEventClickListener listener) {
+    public MyItemRecyclerViewAdapter(List<Event> items, OnEventClickListener listener) {
         mValues = items;
         this.listener = listener;
     }
@@ -42,14 +42,14 @@ public class MyItemRecyclerViewAdapter
     @Override
     public void onBindViewHolder(final ViewHolder holder, int position) {
 
-        PlaceholderItem item = mValues.get(position);
+        Event event = mValues.get(position);
 
-        holder.binding.itemNumber.setText(item.id);
-        holder.binding.content.setText(item.content);
+        holder.binding.itemNumber.setText(event.getTitle());
+        holder.binding.content.setText(event.getDescription());
 
         holder.binding.getRoot().setOnClickListener(v -> {
             if (listener != null) {
-                listener.onEventClick(item);
+                listener.onEventClick(event);
             }
         });
     }

--- a/app/src/main/java/com/example/releasethekraken/view/NotificationAdapter.java
+++ b/app/src/main/java/com/example/releasethekraken/view/NotificationAdapter.java
@@ -1,0 +1,59 @@
+package com.example.releasethekraken.view;
+
+import android.text.format.DateFormat;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.releasethekraken.databinding.ItemNotificationBinding;
+import com.example.releasethekraken.model.Notification;
+
+import java.util.List;
+
+public class NotificationAdapter extends RecyclerView.Adapter<NotificationAdapter.ViewHolder> {
+
+    private final List<Notification> notifications;
+
+    public NotificationAdapter(List<Notification> notifications) {
+        this.notifications = notifications;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        ItemNotificationBinding binding = ItemNotificationBinding.inflate(
+                LayoutInflater.from(parent.getContext()),
+                parent,
+                false
+        );
+        return new ViewHolder(binding);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        Notification notification = notifications.get(position);
+
+        holder.binding.textNotificationType.setText(notification.getType());
+        holder.binding.textNotificationMessage.setText(notification.getMessage());
+        holder.binding.textNotificationEventId.setText("Event: " + notification.getEventId());
+        holder.binding.textNotificationTime.setText(
+                DateFormat.format("yyyy-MM-dd HH:mm", notification.getSentAtMillis()).toString()
+        );
+    }
+
+    @Override
+    public int getItemCount() {
+        return notifications.size();
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+        final ItemNotificationBinding binding;
+
+        ViewHolder(ItemNotificationBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_create_event.xml
+++ b/app/src/main/res/layout/fragment_create_event.xml
@@ -167,7 +167,7 @@
         android:layout_gravity="start"
         android:layout_marginTop="50dp"
         android:backgroundTint="@color/light_grey_button"
-        android:enabled="false"
+        android:enabled="true"
         android:text="@string/create_event_button"
         android:textColor="@color/dark_blue_text"
         android:textStyle="bold"

--- a/app/src/main/res/layout/item_notification.xml
+++ b/app/src/main/res/layout/item_notification.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:layout_marginBottom="8dp">
+
+    <TextView
+        android:id="@+id/text_notification_type"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="WIN"
+        android:textStyle="bold"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/text_notification_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Notification message"
+        android:layout_marginTop="4dp"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/text_notification_event_id"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Event: event123"
+        android:layout_marginTop="6dp"
+        android:textSize="13sp" />
+
+    <TextView
+        android:id="@+id/text_notification_time"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="2026-03-11 15:30"
+        android:layout_marginTop="4dp"
+        android:textSize="12sp" />
+
+</LinearLayout>

--- a/app/src/test/java/com/example/releasethekraken/NotificationServiceTest.java
+++ b/app/src/test/java/com/example/releasethekraken/NotificationServiceTest.java
@@ -160,12 +160,6 @@ public class NotificationServiceTest {
         assertEquals(repo.sentNotification.getSentAtMillis(), repo.loggedNotification.getSentAtMillis());
     }
 
-    // helper method to create a sample event
-    private Event makeSampleEvent() {
-        long now = System.currentTimeMillis();
-        return new Event("event123", now - 1000000, now + 1000000);
-    }
-
     @Test
     public void sendLossNotification_invalidInput_returnsInvalidInput() {
         FakeNotificationRepository repo = new FakeNotificationRepository();
@@ -291,5 +285,17 @@ public class NotificationServiceTest {
         assertEquals(repo.sentNotification.getMessage(), repo.loggedNotification.getMessage());
         assertEquals(repo.sentNotification.getType(), repo.loggedNotification.getType());
         assertEquals(repo.sentNotification.getSentAtMillis(), repo.loggedNotification.getSentAtMillis());
+    }
+
+    // helper method to create a sample event
+    private Event makeSampleEvent() {
+        long now = System.currentTimeMillis();
+        return new Event(
+                "event123",
+                "Sample Event",
+                "Sample Description",
+                now - 1000000,
+                now + 1000000
+        );
     }
 }

--- a/app/src/test/java/com/example/releasethekraken/WaitingListServiceTest.java
+++ b/app/src/test/java/com/example/releasethekraken/WaitingListServiceTest.java
@@ -83,7 +83,7 @@ public class WaitingListServiceTest {
         WaitingListService service = new WaitingListService(repo);
 
         long now = System.currentTimeMillis();
-        Event closedEvent = new Event("event123", now - 200000, now - 100000); // ended in the past
+        Event closedEvent = new Event("event123", "Closed Event", "Description", now - 200000, now - 100000); // ended in the past
 
         final WaitingListService.JoinResult[] result = new WaitingListService.JoinResult[1];
 
@@ -252,6 +252,6 @@ public class WaitingListServiceTest {
     // helper: registration window definitely open now
     private Event makeOpenEvent() {
         long now = System.currentTimeMillis();
-        return new Event("event123", now - 1000000, now + 1000000);
+        return new Event("event123", "Open Event", "Description", now - 1000000, now + 1000000);
     }
 }


### PR DESCRIPTION

- Added CreateEventFragment logic for creating events
- Implemented input validation for required fields (name, description, registration dates).
- Converted registration start and end dates into milliseconds for storage
- Saved new events to Firestore through EventRepository.
- Navigates back to Browse Events after successful event creation.
- Can also waitlist on the events created
- duplicate waitlist is not allowed and met with a message if tried