### PR TITLE
private events now working

### DIFF
--- a/app/src/main/java/com/example/releasethekraken/model/Event.java
+++ b/app/src/main/java/com/example/releasethekraken/model/Event.java
@@ -1,5 +1,8 @@
 package com.example.releasethekraken.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * represents an event
  * stores the basic event information such as the event ID, title,
@@ -22,6 +25,9 @@ public class Event {
     private final long registrationStartMillis; //time in milliseconds when registration starts for the event
     private final long registrationEndMillis; //time in milliseconds when registration ends for the event
     private final int capacity;
+    private final boolean isPrivate;
+    private final ArrayList<String> invitedUserIds;
+    private final String organizerId;
 
     /**
      *  creating a new Event object
@@ -36,7 +42,8 @@ public class Event {
                  long registrationStartMillis, long registrationEndMillis) {
         // This overload keeps older call sites valid while routing everything through the
         // full constructor so capacity normalization only exists in one place.
-        this(eventId, title, description, registrationStartMillis, registrationEndMillis, DEFAULT_CAPACITY);
+        this(eventId, title, description, registrationStartMillis, registrationEndMillis,
+                DEFAULT_CAPACITY, false, new ArrayList<>(), "");
     }
 
     /**
@@ -52,6 +59,27 @@ public class Event {
     public Event(String eventId, String title, String description,
                  long registrationStartMillis, long registrationEndMillis, int capacity) {
         // Store the raw event metadata exactly as provided by the caller.
+        this(eventId, title, description, registrationStartMillis, registrationEndMillis,
+                capacity, false, new ArrayList<>(), "");
+    }
+
+    /**
+     * creating a new Event object with explicit capacity, visibility, invited users, and organizer.
+     *
+     * @param eventId unique ID for the event
+     * @param title title of the event
+     * @param description description of the event
+     * @param registrationStartMillis Time when registration starts
+     * @param registrationEndMillis Time when registration ends
+     * @param capacity maximum number of entrants the event supports
+     * @param isPrivate true if the event is private, false if it is public
+     * @param invitedUserIds list of invited user IDs for private events
+     * @param organizerId unique ID of the organizer who created the event
+     */
+    public Event(String eventId, String title, String description,
+                 long registrationStartMillis, long registrationEndMillis, int capacity,
+                 boolean isPrivate, List<String> invitedUserIds, String organizerId) {
+        // Store the raw event metadata exactly as provided by the caller.
         this.eventId = eventId;
         this.title = title;
         this.description = description;
@@ -60,6 +88,13 @@ public class Event {
         // Capacity is normalized here instead of in every caller so that older documents,
         // blank create-event input, and invalid values all converge to the same behavior.
         this.capacity = capacity > 0 ? capacity : DEFAULT_CAPACITY;
+        this.isPrivate = isPrivate;
+        // Store invited users in a non-null list so the rest of the app does not need
+        // repeated null checks when validating access to private events.
+        this.invitedUserIds = invitedUserIds == null ? new ArrayList<>() : new ArrayList<>(invitedUserIds);
+        // Organizer ID defaults to an empty string so older call sites and older documents
+        // do not break while private-event support is being added.
+        this.organizerId = organizerId == null ? "" : organizerId;
     }
 
     //returns a unique ID for the event
@@ -90,5 +125,20 @@ public class Event {
     //returns capacity
     public int getCapacity() {
         return capacity;
+    }
+
+    //returns whether the event is private
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    //returns the invited user IDs for the event
+    public ArrayList<String> getInvitedUserIds() {
+        return new ArrayList<>(invitedUserIds);
+    }
+
+    //returns the organizer ID for the event
+    public String getOrganizerId() {
+        return organizerId;
     }
 }

--- a/app/src/main/java/com/example/releasethekraken/model/EventRepository.java
+++ b/app/src/main/java/com/example/releasethekraken/model/EventRepository.java
@@ -79,6 +79,12 @@ public class EventRepository {
         data.put("registrationStartMillis", event.getRegistrationStartMillis());
         data.put("registrationEndMillis", event.getRegistrationEndMillis());
         data.put("capacity", event.getCapacity());
+
+        // new for private
+        data.put("isPrivate", event.isPrivate());
+        data.put("invitedUserIds", event.getInvitedUserIds());
+        data.put("organizerId", event.getOrganizerId());
+
         data.put("createdAt", System.currentTimeMillis()); // Added for sorting
         data.put("posterImageUrl", posterImageUrl);        // null if no poster uploaded
 
@@ -105,52 +111,43 @@ public class EventRepository {
                 .document(eventId)
                 .get()
                 .addOnSuccessListener(documentSnapshot -> {
-                    // Treat a missing document as a repository error instead of returning a
-                    // partially constructed Event to the UI layer.
                     if (!documentSnapshot.exists()) {
                         callback.onError(new Exception("Event not found"));
                         return;
                     }
 
-                    // Read each field defensively because older documents may predate newer
-                    // fields like capacity, and Firestore values may be null.
                     String title = documentSnapshot.getString("title");
                     String description = documentSnapshot.getString("description");
                     Long registrationStartMillis = documentSnapshot.getLong("registrationStartMillis");
                     Long registrationEndMillis = documentSnapshot.getLong("registrationEndMillis");
                     Long capacity = documentSnapshot.getLong("capacity");
 
-                    // Normalize missing strings so adapter and search code can treat event data
-                    // as non-null without adding repeated null checks.
-                    if (title == null) {
-                        title = "";
-                    }
-                    if (description == null) {
-                        description = "";
-                    }
-                    // Normalize timestamps to zero when absent. This preserves backward
-                    // compatibility and avoids crashing on incomplete seed data.
-                    if (registrationStartMillis == null) {
-                        registrationStartMillis = 0L;
-                    }
-                    if (registrationEndMillis == null) {
-                        registrationEndMillis = 0L;
-                    }
-                    // Events created before capacity support should still load and remain
-                    // filterable, so repository fallback matches Event.DEFAULT_CAPACITY.
-                    if (capacity == null || capacity <= 0) {
-                        capacity = (long) Event.DEFAULT_CAPACITY;
-                    }
+                    // NEW FIELDS
+                    Boolean isPrivate = documentSnapshot.getBoolean("isPrivate");
+                    List<String> invitedUserIds = (List<String>) documentSnapshot.get("invitedUserIds");
+                    String organizerId = documentSnapshot.getString("organizerId");
 
-                    // Use the Firestore document id as the canonical id, since that is what the
-                    // rest of the app navigates with when opening event details.
+                    if (title == null) title = "";
+                    if (description == null) description = "";
+                    if (registrationStartMillis == null) registrationStartMillis = 0L;
+                    if (registrationEndMillis == null) registrationEndMillis = 0L;
+                    if (capacity == null || capacity <= 0) capacity = (long) Event.DEFAULT_CAPACITY;
+
+                    // Defaults for backward compatibility
+                    if (isPrivate == null) isPrivate = false;
+                    if (invitedUserIds == null) invitedUserIds = new ArrayList<>();
+                    if (organizerId == null) organizerId = "";
+
                     Event event = new Event(
                             documentSnapshot.getId(),
                             title,
                             description,
                             registrationStartMillis,
                             registrationEndMillis,
-                            capacity.intValue()
+                            capacity.intValue(),
+                            isPrivate,
+                            invitedUserIds,
+                            organizerId
                     );
 
                     callback.onSuccess(event);
@@ -170,39 +167,37 @@ public class EventRepository {
                     List<Event> events = new ArrayList<>();
 
                     for (QueryDocumentSnapshot document : queryDocumentSnapshots) {
-                        // Apply the same defensive normalization for collection reads so browse
-                        // and detail screens see consistent Event objects.
                         String title = document.getString("title");
                         String description = document.getString("description");
                         Long registrationStartMillis = document.getLong("registrationStartMillis");
                         Long registrationEndMillis = document.getLong("registrationEndMillis");
                         Long capacity = document.getLong("capacity");
 
-                        if (title == null) {
-                            title = "";
-                        }
-                        if (description == null) {
-                            description = "";
-                        }
-                        if (registrationStartMillis == null) {
-                            registrationStartMillis = 0L;
-                        }
-                        if (registrationEndMillis == null) {
-                            registrationEndMillis = 0L;
-                        }
-                        if (capacity == null || capacity <= 0) {
-                            capacity = (long) Event.DEFAULT_CAPACITY;
-                        }
+                        // NEW FIELDS
+                        Boolean isPrivate = document.getBoolean("isPrivate");
+                        List<String> invitedUserIds = (List<String>) document.get("invitedUserIds");
+                        String organizerId = document.getString("organizerId");
 
-                        // Convert each Firestore document into a model object immediately so the
-                        // view/controller code only works with Event instances from this point on.
+                        if (title == null) title = "";
+                        if (description == null) description = "";
+                        if (registrationStartMillis == null) registrationStartMillis = 0L;
+                        if (registrationEndMillis == null) registrationEndMillis = 0L;
+                        if (capacity == null || capacity <= 0) capacity = (long) Event.DEFAULT_CAPACITY;
+
+                        if (isPrivate == null) isPrivate = false;
+                        if (invitedUserIds == null) invitedUserIds = new ArrayList<>();
+                        if (organizerId == null) organizerId = "";
+
                         Event event = new Event(
                                 document.getId(),
                                 title,
                                 description,
                                 registrationStartMillis,
                                 registrationEndMillis,
-                                capacity.intValue()
+                                capacity.intValue(),
+                                isPrivate,
+                                invitedUserIds,
+                                organizerId
                         );
 
                         events.add(event);
@@ -230,15 +225,21 @@ public class EventRepository {
                     }
 
                     QueryDocumentSnapshot document = (QueryDocumentSnapshot) queryDocumentSnapshots.getDocuments().get(0);
+
                     String title = document.getString("title");
                     String description = document.getString("description");
                     Long registrationStartMillis = document.getLong("registrationStartMillis");
                     Long registrationEndMillis = document.getLong("registrationEndMillis");
                     Long capacity = document.getLong("capacity");
 
-                    if (capacity == null || capacity <= 0) {
-                        capacity = (long) Event.DEFAULT_CAPACITY;
-                    }
+                    Boolean isPrivate = document.getBoolean("isPrivate");
+                    List<String> invitedUserIds = (List<String>) document.get("invitedUserIds");
+                    String organizerId = document.getString("organizerId");
+
+                    if (capacity == null || capacity <= 0) capacity = (long) Event.DEFAULT_CAPACITY;
+                    if (isPrivate == null) isPrivate = false;
+                    if (invitedUserIds == null) invitedUserIds = new ArrayList<>();
+                    if (organizerId == null) organizerId = "";
 
                     Event event = new Event(
                             document.getId(),
@@ -246,8 +247,12 @@ public class EventRepository {
                             description != null ? description : "",
                             registrationStartMillis != null ? registrationStartMillis : 0L,
                             registrationEndMillis != null ? registrationEndMillis : 0L,
-                            capacity.intValue()
+                            capacity.intValue(),
+                            isPrivate,
+                            invitedUserIds,
+                            organizerId
                     );
+
                     callback.onSuccess(event);
                 })
                 .addOnFailureListener(callback::onError);

--- a/app/src/main/java/com/example/releasethekraken/repository/ProfileRepository.java
+++ b/app/src/main/java/com/example/releasethekraken/repository/ProfileRepository.java
@@ -168,6 +168,50 @@ public class ProfileRepository {
     }
 
     /**
+     * Searches for a profile by name, email, or phone.
+     * This is a simple implementation that matches exactly.
+     *
+     * @param query    The search string
+     * @param callback Callback for success/failure
+     */
+    public void searchProfiles(String query, ProfileRepositoryCallback<Profile> callback) {
+        // Try searching by name first
+        firestore.collection(COLLECTION_PROFILES)
+                .whereEqualTo("name", query)
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    if (!queryDocumentSnapshots.isEmpty()) {
+                        callback.onSuccess(queryDocumentSnapshots.getDocuments().get(0).toObject(Profile.class));
+                    } else {
+                        // Try email
+                        firestore.collection(COLLECTION_PROFILES)
+                                .whereEqualTo("email", query)
+                                .get()
+                                .addOnSuccessListener(snapshots -> {
+                                    if (!snapshots.isEmpty()) {
+                                        callback.onSuccess(snapshots.getDocuments().get(0).toObject(Profile.class));
+                                    } else {
+                                        // Try phone
+                                        firestore.collection(COLLECTION_PROFILES)
+                                                .whereEqualTo("phone", query)
+                                                .get()
+                                                .addOnSuccessListener(phoneSnapshots -> {
+                                                    if (!phoneSnapshots.isEmpty()) {
+                                                        callback.onSuccess(phoneSnapshots.getDocuments().get(0).toObject(Profile.class));
+                                                    } else {
+                                                        callback.onFailure(new Exception("User not found"));
+                                                    }
+                                                })
+                                                .addOnFailureListener(callback::onFailure);
+                                    }
+                                })
+                                .addOnFailureListener(callback::onFailure);
+                    }
+                })
+                .addOnFailureListener(callback::onFailure);
+    }
+
+    /**
      * Updates an existing profile both locally and in Firestore.
      *
      * @param profile   The updated profile

--- a/app/src/main/java/com/example/releasethekraken/view/BrowseEventsFragment.java
+++ b/app/src/main/java/com/example/releasethekraken/view/BrowseEventsFragment.java
@@ -22,6 +22,8 @@ import com.example.releasethekraken.controller.EventFilterService;
 import com.example.releasethekraken.model.Event;
 import com.example.releasethekraken.model.EventRepository;
 import com.example.releasethekraken.model.UserRole;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -111,6 +113,30 @@ public class BrowseEventsFragment extends Fragment {
         // Event taps still navigate using the existing event-details flow. Search/filtering only
         // changes which events are visible, not how selection/navigation works.
         adapter = new MyItemRecyclerViewAdapter(visibleEvents, event -> {
+            FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
+
+            // Private events remain visible in the list, but only invited users or the organizer
+            // are allowed to open them.
+            if (event.isPrivate()) {
+                if (currentUser == null) {
+                    Toast.makeText(getContext(),
+                            "You must be logged in to access a private event",
+                            Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
+                String currentUserId = currentUser.getUid();
+                boolean isOrganizer = event.getOrganizerId().equals(currentUserId);
+                boolean isInvited = event.getInvitedUserIds().contains(currentUserId);
+
+                if (!isOrganizer && !isInvited) {
+                    Toast.makeText(getContext(),
+                            "You are not invited to this private event",
+                            Toast.LENGTH_SHORT).show();
+                    return;
+                }
+            }
+
             Bundle args = new Bundle();
             args.putString("eventId", event.getEventId());
 
@@ -249,7 +275,7 @@ public class BrowseEventsFragment extends Fragment {
     }
 
     private void updateVisibleEvents(List<Event> filteredEvents) {
-        // Update the adapter backing list in place so the existing adapter instance can be reused.
+        // Private events stay visible in the browse list. Access is enforced on click instead.
         visibleEvents.clear();
         visibleEvents.addAll(filteredEvents);
         adapter.notifyDataSetChanged();

--- a/app/src/main/java/com/example/releasethekraken/view/CreateEventFragment.java
+++ b/app/src/main/java/com/example/releasethekraken/view/CreateEventFragment.java
@@ -26,38 +26,30 @@ import com.example.releasethekraken.databinding.FragmentCreateEventBinding;
 import com.example.releasethekraken.model.Event;
 import com.example.releasethekraken.model.EventRepository;
 import com.example.releasethekraken.model.UserRole;
+import com.example.releasethekraken.repository.ProfileRepository;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 
+import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
-/**
- * This is the fragment that is used to create events and add them to the repository. It is also
- * used in editing information about events and updating that information in the repository.
- *
- * It takes three arguments from the navigator when this event is navigated to;
- * Boolean editEvent that is true when editing the events and false when not editing the events and
- *  is used to adjust UI elements and update the event instead of creating a new one.
- * Boolean cameFromYourEvents that determines if the user entered the event creator via your events
- *  or browse events. It is true when you have come from your events and is used in backwards navigability.
- * String eventID contains the string version of the event ID and is used when the event is chosen to be
- *  edited so that it can properly prefill the relevant fields to be edited.
- */
 public class CreateEventFragment extends Fragment {
 
     private FragmentCreateEventBinding binding;
     private boolean editEvent, cameFromYourEvents;
     private String eventID;
 
-    // Uri of the poster image the user picked from the gallery (null = no image chosen)
     private Uri selectedPosterUri = null;
 
-    // Launcher for the gallery image picker
+    // store invited users (IDs)
+    private final ArrayList<String> invitedUserIds = new ArrayList<>();
+
     private final ActivityResultLauncher<String> imagePickerLauncher =
             registerForActivityResult(new ActivityResultContracts.GetContent(), uri -> {
                 if (uri != null) {
                     selectedPosterUri = uri;
-                    // Preview the chosen poster immediately in the button
                     Glide.with(this)
                             .load(uri)
                             .centerCrop()
@@ -94,49 +86,112 @@ public class CreateEventFragment extends Fragment {
         if (editEvent) {
             binding.eventCreateWelcome.setText(R.string.edit_event_welcome);
             binding.createEvent.setText(R.string.edit_event_confirm_button);
+            loadEventToEdit();
         }
 
-        // Open gallery when poster image button is tapped
         binding.imageButton.setOnClickListener(v ->
                 imagePickerLauncher.launch("image/*")
         );
 
-        // Navigate back to main menu
+        //private switch logic
+        binding.privateEventSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked) {
+                binding.inviteSectionTitle.setVisibility(View.VISIBLE);
+                binding.inviteSearchInput.setVisibility(View.VISIBLE);
+                binding.addInviteButton.setVisibility(View.VISIBLE);
+                binding.invitedUsersPreview.setVisibility(View.VISIBLE);
+            } else {
+                binding.inviteSectionTitle.setVisibility(View.GONE);
+                binding.inviteSearchInput.setVisibility(View.GONE);
+                binding.addInviteButton.setVisibility(View.GONE);
+                binding.invitedUsersPreview.setVisibility(View.GONE);
+            }
+        });
+
+        // INVITE BUTTON searching for real users (EMAIL HAS BEEN THE BEST WORKING)
+        binding.addInviteButton.setOnClickListener(v -> {
+            String input = binding.inviteSearchInput.getText().toString().trim();
+
+            if (TextUtils.isEmpty(input)) {
+                Toast.makeText(getContext(), "Enter a name, email, or phone to invite", Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            binding.addInviteButton.setEnabled(false);
+            new ProfileRepository(requireContext())
+                    .searchProfiles(input, new ProfileRepository.ProfileRepositoryCallback<com.example.releasethekraken.model.Profile>() {
+                        @Override
+                        public void onSuccess(com.example.releasethekraken.model.Profile profile) {
+                            if (!isAdded()) return;
+                            binding.addInviteButton.setEnabled(true);
+                            if (invitedUserIds.contains(profile.getUid())) {
+                                Toast.makeText(getContext(), "User already invited", Toast.LENGTH_SHORT).show();
+                                return;
+                            }
+                            invitedUserIds.add(profile.getUid());
+                            binding.inviteSearchInput.setText("");
+                            binding.invitedUsersPreview.setText("Invited: " + invitedUserIds.size() + " (" + profile.getName() + ")");
+                            Toast.makeText(getContext(), "Added " + profile.getName(), Toast.LENGTH_SHORT).show();
+                        }
+
+                        @Override
+                        public void onFailure(Exception exception) {
+                            if (!isAdded()) return;
+                            binding.addInviteButton.setEnabled(true);
+                            Toast.makeText(getContext(), "User not found", Toast.LENGTH_SHORT).show();
+                        }
+                    });
+        });
+
         binding.cancelEventCreation.setOnClickListener(v -> {
             if (editEvent) {
-                // An existing event had its edits cancelled so we return to its details page
                 Bundle args = new Bundle();
                 args.putSerializable("UserType", UserRole.ORGANIZER);
                 args.putString("eventId", eventID);
                 args.putBoolean("cameFromYourEvents", cameFromYourEvents);
                 Navigation.findNavController(v).navigate(R.id.action_createEventFragment_to_eventDetailsFragment, args);
             } else {
-                // A new event being created was canceled, so the user had to have come from your events
                 Bundle args = new Bundle();
                 args.putBoolean("yourEvents", true);
                 Navigation.findNavController(v).navigate(R.id.action_createEventFragment_to_browseEventsFragment, args);
             }
         });
 
-        // Create event and save to Firestore
         binding.createEvent.setOnClickListener(v -> createEventAndSave());
     }
 
-    /**
-     * The method that is called to handle event creations based on the information in the fields
-     * and writes the event into the repository and the database. Sets up a worker to trigger on
-     * registration closing
-     */
+    private void loadEventToEdit() {
+        if (eventID == null) return;
+        new EventRepository().getEventById(eventID, new EventRepository.EventCallback() {
+            @Override
+            public void onSuccess(Event event) {
+                if (!isAdded()) return;
+                binding.nameEventCreate.setText(event.getTitle());
+                binding.eventDescriptionText.setText(event.getDescription());
+                java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("dd/MM/yyyy h:mm a", java.util.Locale.ENGLISH);
+                binding.registrationStartDate.setText(sdf.format(new java.util.Date(event.getRegistrationStartMillis())));
+                binding.registrationEndDate.setText(sdf.format(new java.util.Date(event.getRegistrationEndMillis())));
+                binding.maxEntrantsEditText.setText(String.valueOf(event.getCapacity()));
+                binding.privateEventSwitch.setChecked(event.isPrivate());
+                invitedUserIds.clear();
+                invitedUserIds.addAll(event.getInvitedUserIds());
+                binding.invitedUsersPreview.setText("Invited: " + invitedUserIds.size());
+            }
+
+            @Override
+            public void onError(Exception e) {
+                Toast.makeText(getContext(), "Failed to load event for editing", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
     private void createEventAndSave() {
-        // Pull the raw user input first so validation can happen before any repository work.
         String title = binding.nameEventCreate.getText().toString().trim();
         String description = binding.eventDescriptionText.getText().toString().trim();
         String startText = binding.registrationStartDate.getText().toString().trim();
         String endText = binding.registrationEndDate.getText().toString().trim();
         String capacityText = binding.maxEntrantsEditText.getText().toString().trim();
 
-        // Capacity is optional, but the rest of the event data is required to create a usable
-        // browseable event in Firestore.
         if (TextUtils.isEmpty(title) || TextUtils.isEmpty(description) || TextUtils.isEmpty(startText) || TextUtils.isEmpty(endText)) {
             Toast.makeText(getContext(), "Please fill in all required fields", Toast.LENGTH_SHORT).show();
             return;
@@ -144,8 +199,6 @@ public class CreateEventFragment extends Fragment {
 
         long registrationStartMillis, registrationEndMillis;
         try {
-            // Keep create-event input and browse-event filter input on the same date format so
-            // the user only has to learn one timestamp convention in the app.
             java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("dd/MM/yyyy h:mm a", java.util.Locale.ENGLISH);
             sdf.setLenient(false);
             registrationStartMillis = sdf.parse(startText).getTime();
@@ -155,35 +208,44 @@ public class CreateEventFragment extends Fragment {
             return;
         }
 
-        // Registration end drives worker scheduling, so reject inverted windows before saving.
         if (registrationEndMillis <= registrationStartMillis) {
             Toast.makeText(getContext(), "Registration end must be after registration start", Toast.LENGTH_SHORT).show();
             return;
         }
 
-        // Blank capacity means "use the app default". Any provided value must be a positive whole
-        // number because browse-time filtering compares numeric capacities.
         int capacity = Event.DEFAULT_CAPACITY;
         if (!capacityText.isEmpty()) {
             try {
                 capacity = Integer.parseInt(capacityText);
             } catch (NumberFormatException e) {
-                Toast.makeText(getContext(),
-                        "Maximum entrants must be a whole number",
-                        Toast.LENGTH_SHORT).show();
+                Toast.makeText(getContext(), "Maximum entrants must be a whole number", Toast.LENGTH_SHORT).show();
                 return;
             }
             if (capacity <= 0) {
-                Toast.makeText(getContext(),
-                        "Maximum entrants must be greater than zero",
-                        Toast.LENGTH_SHORT).show();
+                Toast.makeText(getContext(), "Maximum entrants must be greater than zero", Toast.LENGTH_SHORT).show();
                 return;
             }
         }
 
-        // Current app flow still derives an id from the title. Not ideal long-term, but kept
-        // unchanged here so the new filtering work does not alter navigation semantics.
-        String eventId = title.replaceAll("\\s+", "_").toLowerCase();
+        String eventId = editEvent ? eventID : title.replaceAll("\\s+", "_").toLowerCase();
+
+        // get private state
+        boolean isPrivate = binding.privateEventSwitch.isChecked();
+
+        // Use real organizer UID
+        String organizerId = "";
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        if (user != null) {
+            organizerId = user.getUid();
+        } else {
+            // Fallback to local profile UID if available
+            organizerId = new ProfileRepository(requireContext()).getProfile().getUid();
+        }
+
+        if (TextUtils.isEmpty(organizerId)) {
+            Toast.makeText(getContext(), "Error: Could not identify organizer. Please ensure you are logged in.", Toast.LENGTH_LONG).show();
+            return;
+        }
 
         Event event = new Event(
                 eventId,
@@ -191,32 +253,22 @@ public class CreateEventFragment extends Fragment {
                 description,
                 registrationStartMillis,
                 registrationEndMillis,
-                capacity
+                capacity,
+                isPrivate,
+                invitedUserIds,
+                organizerId
         );
 
-        // Disable the button while Firestore writes so duplicate taps do not create duplicate
-        // events or enqueue multiple draw workers.
         binding.loading.setVisibility(View.VISIBLE);
         binding.createEvent.setEnabled(false);
 
         if (selectedPosterUri != null) {
-            // Upload poster first, then save event with the returned URL
             uploadPosterAndSave(event, eventId, registrationEndMillis);
         } else {
             saveEventToFirestore(event, eventId, registrationEndMillis, null);
         }
     }
 
-    /**
-     * Uploads the selected poster image to Firebase Storage, then saves the event
-     * with the returned download URL stored in Firestore.
-     *
-     * Storage path: event_posters/{eventId}.jpg
-     *
-     * @param event                the event to save
-     * @param eventId              the event document ID
-     * @param registrationEndMillis used to schedule the draw worker
-     */
     private void uploadPosterAndSave(Event event, String eventId, long registrationEndMillis) {
         StorageReference ref = FirebaseStorage.getInstance().getReference()
                 .child("event_posters")
@@ -228,32 +280,14 @@ public class CreateEventFragment extends Fragment {
                                 .addOnSuccessListener(uri ->
                                         saveEventToFirestore(event, eventId, registrationEndMillis, uri.toString())
                                 )
-                                .addOnFailureListener(e -> {
-                                    if (!isAdded()) return;
-                                    Toast.makeText(getContext(),
-                                            "Poster upload failed, saving event without image: " + e.getMessage(),
-                                            Toast.LENGTH_LONG).show();
-                                    // Still save the event even if poster upload failed
-                                    saveEventToFirestore(event, eventId, registrationEndMillis, null);
-                                }))
-                .addOnFailureListener(e -> {
-                    if (!isAdded()) return;
-                    Toast.makeText(getContext(),
-                            "Poster upload failed, saving event without image: " + e.getMessage(),
-                            Toast.LENGTH_LONG).show();
-                    // Still save the event even if poster upload failed
-                    saveEventToFirestore(event, eventId, registrationEndMillis, null);
-                });
+                                .addOnFailureListener(e ->
+                                        saveEventToFirestore(event, eventId, registrationEndMillis, null)
+                                ))
+                .addOnFailureListener(e ->
+                        saveEventToFirestore(event, eventId, registrationEndMillis, null)
+                );
     }
 
-    /**
-     * Saves the event to Firestore, optionally including a poster image URL.
-     *
-     * @param event                the event to save
-     * @param eventId              the event document ID
-     * @param registrationEndMillis used to schedule the draw worker
-     * @param posterImageUrl       Firebase Storage download URL, or null if no poster was uploaded
-     */
     private void saveEventToFirestore(Event event, String eventId,
                                       long registrationEndMillis, @Nullable String posterImageUrl) {
         new EventRepository().createEvent(event, posterImageUrl, new EventRepository.CompletionCallback() {
@@ -264,29 +298,22 @@ public class CreateEventFragment extends Fragment {
                 binding.loading.setVisibility(View.GONE);
                 binding.createEvent.setEnabled(true);
 
-                // Worker delay is based on the registration close time. This keeps entrant drawing
-                // aligned with the same registration window used by browse-event availability
-                // filtering.
                 long delay = registrationEndMillis - System.currentTimeMillis();
 
-                // Pass the event id into the worker so the background draw job knows which event
-                // should be processed once registration closes.
                 Data inputData = new Data.Builder()
                         .putString("eventId", eventId)
                         .build();
 
-                // Queue a one-time worker instead of blocking the UI thread or relying on the
-                // fragment still being alive when registration closes.
                 OneTimeWorkRequest drawRequest =
                         new OneTimeWorkRequest.Builder(DrawEntrantsWorker.class)
                                 .setInitialDelay(delay, TimeUnit.MILLISECONDS)
                                 .setInputData(inputData)
                                 .build();
+
                 WorkManager.getInstance(requireContext()).enqueue(drawRequest);
 
-                Toast.makeText(getContext(), "Event created successfully", Toast.LENGTH_SHORT).show();
+                Toast.makeText(getContext(), editEvent ? "Event updated successfully" : "Event created successfully", Toast.LENGTH_SHORT).show();
 
-                // Navigate to details instead of browse
                 Bundle args = new Bundle();
                 args.putString("eventId", eventId);
                 args.putSerializable("UserType", UserRole.ORGANIZER);

--- a/app/src/main/java/com/example/releasethekraken/view/EventDetailsFragment.java
+++ b/app/src/main/java/com/example/releasethekraken/view/EventDetailsFragment.java
@@ -3,6 +3,7 @@ package com.example.releasethekraken.view;
 import android.app.AlertDialog;
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.text.format.DateFormat;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -16,7 +17,6 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.constraintlayout.widget.Group;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
 
@@ -30,6 +30,7 @@ import com.example.releasethekraken.model.WaitingListRepository;
 import com.example.releasethekraken.repository.ProfileRepository;
 import com.example.releasethekraken.util.QRCodeGenerator;
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 
 /**
  * A fragment that shows the details of an event that can be accessed when an event is clicked from
@@ -59,6 +60,7 @@ public class EventDetailsFragment extends Fragment {
     private Event currentEvent;
     private UserRole userType;
     private boolean cameFromYourEvents;
+    private Button viewQrButton;
 
     private boolean isJoined = false;
 
@@ -101,7 +103,7 @@ public class EventDetailsFragment extends Fragment {
         Button createNotificationButton = view.findViewById(R.id.create_notification_button);
         Button editEventButton = view.findViewById(R.id.edit_event_button);
         Button viewEntrantMapButton = view.findViewById(R.id.view_entrant_map_button);
-        Button viewQrButton = view.findViewById(R.id.view_qr_button);
+        viewQrButton = view.findViewById(R.id.view_qr_button);
         Button viewWaitingListButton = view.findViewById(R.id.view_waiting_list_button);
         Button viewCommentsButton = view.findViewById(R.id.view_comments_button);
         Button exportToCsvButton = view.findViewById(R.id.export_csv_button);
@@ -131,9 +133,9 @@ public class EventDetailsFragment extends Fragment {
             Navigation.findNavController(view).navigate(R.id.action_eventDetailsFragment_to_browseEventsFragment, args);
         });
 
-        deleteEventButton.setOnClickListener(v -> showDeleteConfirmationDialog(v));
+        deleteEventButton.setOnClickListener(this::showDeleteConfirmationDialog);
         createNotificationButton.setOnClickListener(v -> showCreateNotificationDialog());
-        editEventButton.setOnClickListener(v -> navigateToEditEvent(v));
+        editEventButton.setOnClickListener(this::navigateToEditEvent);
 
         viewWaitingListButton.setOnClickListener(v -> {
             Bundle args = new Bundle();
@@ -181,9 +183,44 @@ public class EventDetailsFragment extends Fragment {
         eventRepository.getEventById(eventId, new EventRepository.EventCallback() {
             @Override
             public void onSuccess(Event event) {
+                FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
+                String currentUserId = currentUser != null ? currentUser.getUid() : new ProfileRepository(requireContext()).getProfile().getUid();
+
+                // Private events can only be opened by the organizer or an invited entrant.
+                if (event.isPrivate()) {
+                    if (TextUtils.isEmpty(currentUserId)) {
+                        if (isAdded()) {
+                            Toast.makeText(requireContext(),
+                                    "You must be logged in to access this event",
+                                    Toast.LENGTH_SHORT).show();
+                            Navigation.findNavController(requireView()).popBackStack();
+                        }
+                        return;
+                    }
+
+                    boolean isOrganizer = event.getOrganizerId().equals(currentUserId);
+                    boolean isInvited = event.getInvitedUserIds().contains(currentUserId);
+
+                    if (!isOrganizer && !isInvited) {
+                        if (isAdded()) {
+                            Toast.makeText(requireContext(),
+                                    "You are not invited to this private event",
+                                    Toast.LENGTH_SHORT).show();
+                            Navigation.findNavController(requireView()).popBackStack();
+                        }
+                        return;
+                    }
+                }
+
                 currentEvent = event;
+
+                // Private events do not have a QR code for joining
+                if (currentEvent.isPrivate()) {
+                    viewQrButton.setVisibility(View.GONE);
+                }
+
                 bindEventToViews();
-                checkIfJoined();
+                checkIfJoined(currentUserId);
             }
             @Override
             public void onError(Exception e) {
@@ -239,14 +276,15 @@ public class EventDetailsFragment extends Fragment {
         }
     }
 
-    private void checkIfJoined() {
-        new WaitingListRepository().isUserInWaitingList(eventId, "testEntrant001", new WaitingListRepository.CheckCallback() {
+    private void checkIfJoined(String currentUserId) {
+        if (currentUserId == null || currentUserId.isEmpty()) return;
+        new WaitingListRepository().isUserInWaitingList(eventId, currentUserId, new WaitingListRepository.CheckCallback() {
             @Override
             public void onResult(boolean exists) {
                 isJoined = exists;
                 if (getView() != null) {
                     Button btn = getView().findViewById(R.id.signup_optout_button);
-                    btn.setText(isJoined ? "Leave Waiting List" : "Join Waiting List");
+                    btn.setText(isJoined ? R.string.opt_out_button : R.string.signup_button);
                 }
             }
             @Override public void onError(Exception e) {}

--- a/app/src/main/res/layout/fragment_create_event.xml
+++ b/app/src/main/res/layout/fragment_create_event.xml
@@ -142,7 +142,6 @@
         android:padding="25dp"
         android:scaleType="fitCenter"
         android:src="@android:drawable/stat_sys_upload_done"
-        app:layout_constraintBottom_toTopOf="@+id/create_account"
         app:layout_constraintEnd_toStartOf="@+id/max_entrants_editText"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView3"
@@ -160,39 +159,6 @@
         app:layout_constraintStart_toStartOf="@+id/imageButton"
         app:layout_constraintTop_toBottomOf="@+id/imageButton" />
 
-    <Button
-        android:id="@+id/create_event"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:layout_marginTop="50dp"
-        android:backgroundTint="@color/light_grey_button"
-        android:enabled="true"
-        android:text="@string/create_event_button"
-        android:textColor="@color/dark_blue_text"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/cancel_event_creation"
-        app:layout_constraintTop_toBottomOf="@+id/imageButton"
-        app:layout_constraintVertical_bias="0.501" />
-
-    <Button
-        android:id="@+id/cancel_event_creation"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="50dp"
-        android:layout_marginEnd="7dp"
-        android:backgroundTint="@color/light_grey_button"
-        android:text="@string/cancel_button"
-        android:textColor="@color/dark_blue_text"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/create_event"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/imageButton"
-        app:layout_constraintVertical_bias="0.501" />
-
     <ProgressBar
         android:id="@+id/loading"
         android:layout_width="wrap_content"
@@ -204,8 +170,8 @@
         android:layout_marginBottom="64dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@+id/password"
-        app:layout_constraintStart_toStartOf="@+id/password"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.3" />
 
@@ -217,9 +183,101 @@
         android:textAlignment="center"
         android:textColor="@color/dark_blue_text"
         android:textStyle="bold"
-        app:layout_constraintBottom_toTopOf="@+id/create_event"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/imageButton"
         app:layout_constraintTop_toBottomOf="@+id/textView" />
+
+    <Switch
+        android:id="@+id/private_event_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Private Event"
+        android:textAlignment="center"
+        android:textColor="@color/dark_blue_text"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/imageButton"
+        app:layout_constraintTop_toBottomOf="@+id/enable_geolocation_switch" />
+
+    <TextView
+        android:id="@+id/invite_section_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:text="Invite Users"
+        android:textColor="@color/dark_blue_text"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@+id/private_event_switch"
+        app:layout_constraintTop_toBottomOf="@+id/private_event_switch" />
+
+    <EditText
+        android:id="@+id/invite_search_input"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:ems="10"
+        android:hint="Search by name, email, or phone"
+        android:inputType="text"
+        android:visibility="gone"
+        app:layout_constraintEnd_toStartOf="@+id/add_invite_button"
+        app:layout_constraintStart_toStartOf="@+id/invite_section_title"
+        app:layout_constraintTop_toBottomOf="@+id/invite_section_title" />
+
+    <Button
+        android:id="@+id/add_invite_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="10dp"
+        android:backgroundTint="@color/light_grey_button"
+        android:text="Add"
+        android:textColor="@color/dark_blue_text"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintBaseline_toBaselineOf="@+id/invite_search_input"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/invite_search_input" />
+
+    <TextView
+        android:id="@+id/invited_users_preview"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="No users invited"
+        android:textColor="@color/dark_blue_text"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="@+id/add_invite_button"
+        app:layout_constraintStart_toStartOf="@+id/invite_search_input"
+        app:layout_constraintTop_toBottomOf="@+id/invite_search_input" />
+
+    <Button
+        android:id="@+id/create_event"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="50dp"
+        android:backgroundTint="@color/light_grey_button"
+        android:enabled="true"
+        android:text="@string/create_event_button"
+        android:textColor="@color/dark_blue_text"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/cancel_event_creation"
+        app:layout_constraintTop_toBottomOf="@+id/invited_users_preview" />
+
+    <Button
+        android:id="@+id/cancel_event_creation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="50dp"
+        android:layout_marginEnd="7dp"
+        android:backgroundTint="@color/light_grey_button"
+        android:text="@string/cancel_button"
+        android:textColor="@color/dark_blue_text"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toStartOf="@+id/create_event"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/invited_users_preview" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Implemented private event functionality and invite only access control

## Features Added
- Ability to create private events
- Private events visible in browse list but restricted access (cannot click unless invited)
- Invite-only waiting list system
- Organizer and invited users can access private events
- Non-invited users are blocked from accessing event details

## Technical Changes
- Updated Event to include:
  - isPrivate
  - invitedUserIds
  - organizerId
- Updated EventRepository to store/retrieve new fields
- Modified CreateEventFragment:
  - Added private event toggle
  - Invite user UI
- Updated BrowseEventsFragment:
  - Access control enforced on click
- Updated EventDetailsFragment:
  - Secure access enforcement (prevents deep link bypass)

## Notes
- if you try it and want to send invite, the best thing is to use the users email that you are inviting and that the user is in the firebase.