### PR TITLE
US 02.06.01 & 02.06.02: View invited and cancelled entrants with Firestore integration

### DIFF
--- a/app/src/main/java/com/example/releasethekraken/model/NotificationRepository.java
+++ b/app/src/main/java/com/example/releasethekraken/model/NotificationRepository.java
@@ -41,6 +41,11 @@ public class NotificationRepository {
         void onError(Exception e);
     }
 
+    public interface EntrantIdsCallback {
+        void onSuccess(List<String> entrantIds);
+        void onError(Exception e);
+    }
+
     public void sendNotification(Notification notification, CompletionCallback callback) {
         Map<String, Object> data = new HashMap<>();
         data.put("entrantId", notification.getEntrantId());
@@ -168,6 +173,27 @@ public class NotificationRepository {
                 callback.onError(e);
             }
         });
+    }
+
+    public void getFinalAcceptedEntrantsForEvent(String eventId, EntrantIdsCallback callback) {
+        if (eventId == null || eventId.trim().isEmpty()) {
+            callback.onError(new IllegalArgumentException("Invalid event ID."));
+            return;
+        }
+
+        db.collection("events")
+                .document(eventId)
+                .collection("accepted")
+                .whereEqualTo("status", "accepted")
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    List<String> entrantIds = new ArrayList<>();
+                    for (QueryDocumentSnapshot document : queryDocumentSnapshots) {
+                        entrantIds.add(document.getId());
+                    }
+                    callback.onSuccess(entrantIds);
+                })
+                .addOnFailureListener(callback::onError);
     }
 
     private void getInvitationNotificationsForEvent(String eventId, NotificationsCallback callback) {
@@ -355,7 +381,6 @@ public class NotificationRepository {
 
         batch.commit()
                 .addOnSuccessListener(unused -> {
-                    // Replacement should only happen for lottery winners (WIN or SELECTED types)
                     if ("WIN".equalsIgnoreCase(type) || "SELECTED".equalsIgnoreCase(type)) {
                         triggerReplacementSelection(eventId, entrantId, callback);
                     } else {

--- a/app/src/main/java/com/example/releasethekraken/view/EventDetailsFragment.java
+++ b/app/src/main/java/com/example/releasethekraken/view/EventDetailsFragment.java
@@ -77,6 +77,7 @@ public class EventDetailsFragment extends Fragment {
     private View viewWaitingListButton;
     private View viewInvitedEntrantsButton;
     private View viewCancelledEntrantsButton;
+    private View viewFinalAttendeesButton;
     private View viewCommentsButton;
 
     private WaitingListRepository waitingListRepository;
@@ -164,6 +165,7 @@ public class EventDetailsFragment extends Fragment {
         viewWaitingListButton = view.findViewById(R.id.view_waiting_list_button);
         viewInvitedEntrantsButton = view.findViewById(R.id.view_invited_entrants_button);
         viewCancelledEntrantsButton = view.findViewById(R.id.view_cancelled_entrants_button);
+        viewFinalAttendeesButton = view.findViewById(R.id.view_final_attendees_button);
         viewCommentsButton = view.findViewById(R.id.view_comments_button);
         exportToCsvButton = view.findViewById(R.id.export_csv_button);
         redrawButton = view.findViewById(R.id.redraw_button);
@@ -200,9 +202,41 @@ public class EventDetailsFragment extends Fragment {
             Navigation.findNavController(v).navigate(R.id.action_eventDetailsFragment_to_entrantMapFragment, args);
         });
 
-        viewWaitingListButton.setOnClickListener(v -> navigateToUserList(view, "waiting"));
-        viewInvitedEntrantsButton.setOnClickListener(v -> navigateToUserList(view, "invited"));
-        viewCancelledEntrantsButton.setOnClickListener(v -> navigateToUserList(view, "cancelled"));
+        viewWaitingListButton.setOnClickListener(v -> {
+            Bundle args = new Bundle();
+            args.putBoolean("adminView", false);
+            args.putString(ARG_EVENT_ID, eventId);
+            args.putSerializable("userRole", userType);
+            args.putString("listMode", "waiting");
+            Navigation.findNavController(view).navigate(R.id.action_eventDetailsFragment_to_userListFragment, args);
+        });
+
+        viewInvitedEntrantsButton.setOnClickListener(v -> {
+            Bundle args = new Bundle();
+            args.putBoolean("adminView", false);
+            args.putString(ARG_EVENT_ID, eventId);
+            args.putSerializable("userRole", userType);
+            args.putString("listMode", "invited");
+            Navigation.findNavController(view).navigate(R.id.action_eventDetailsFragment_to_userListFragment, args);
+        });
+
+        viewCancelledEntrantsButton.setOnClickListener(v -> {
+            Bundle args = new Bundle();
+            args.putBoolean("adminView", false);
+            args.putString(ARG_EVENT_ID, eventId);
+            args.putSerializable("userRole", userType);
+            args.putString("listMode", "cancelled");
+            Navigation.findNavController(view).navigate(R.id.action_eventDetailsFragment_to_userListFragment, args);
+        });
+
+        viewFinalAttendeesButton.setOnClickListener(v -> {
+            Bundle args = new Bundle();
+            args.putBoolean("adminView", false);
+            args.putString(ARG_EVENT_ID, eventId);
+            args.putSerializable("userRole", userType);
+            args.putString("listMode", "final");
+            Navigation.findNavController(view).navigate(R.id.action_eventDetailsFragment_to_userListFragment, args);
+        });
 
         viewCommentsButton.setOnClickListener(v -> {
             Bundle args = new Bundle();
@@ -210,15 +244,6 @@ public class EventDetailsFragment extends Fragment {
             args.putSerializable("userRole", userType);
             Navigation.findNavController(view).navigate(R.id.action_eventDetailsFragment_to_commentsFragment, args);
         });
-    }
-
-    private void navigateToUserList(View view, String listMode) {
-        Bundle args = new Bundle();
-        args.putBoolean("adminView", false);
-        args.putString(ARG_EVENT_ID, eventId);
-        args.putSerializable("userRole", userType);
-        args.putString("listMode", listMode);
-        Navigation.findNavController(view).navigate(R.id.action_eventDetailsFragment_to_userListFragment, args);
     }
 
     private void updateUIForRole() {
@@ -232,6 +257,7 @@ public class EventDetailsFragment extends Fragment {
             viewWaitingListButton.setVisibility(View.GONE);
             viewInvitedEntrantsButton.setVisibility(View.GONE);
             viewCancelledEntrantsButton.setVisibility(View.GONE);
+            viewFinalAttendeesButton.setVisibility(View.GONE);
             viewCommentsButton.setVisibility(View.VISIBLE);
             signupOptOutButton.setVisibility(View.VISIBLE);
             sendInviteButton.setVisibility(View.GONE);
@@ -245,6 +271,7 @@ public class EventDetailsFragment extends Fragment {
             viewWaitingListButton.setVisibility(View.VISIBLE);
             viewInvitedEntrantsButton.setVisibility(View.VISIBLE);
             viewCancelledEntrantsButton.setVisibility(View.VISIBLE);
+            viewFinalAttendeesButton.setVisibility(View.VISIBLE);
             viewCommentsButton.setVisibility(View.VISIBLE);
             signupOptOutButton.setVisibility(View.GONE);
 

--- a/app/src/main/java/com/example/releasethekraken/view/UserListFragment.java
+++ b/app/src/main/java/com/example/releasethekraken/view/UserListFragment.java
@@ -43,6 +43,7 @@ public class UserListFragment extends Fragment {
     private static final String MODE_WAITING = "waiting";
     private static final String MODE_INVITED = "invited";
     private static final String MODE_CANCELLED = "cancelled";
+    private static final String MODE_FINAL = "final";
 
     private int mColumnCount = 1;
     private boolean adminView;
@@ -130,6 +131,9 @@ public class UserListFragment extends Fragment {
             } else if (MODE_CANCELLED.equals(listMode)) {
                 welcomeText.setText("Cancelled / Declined Entrants");
                 loadCancelledEntrants();
+            } else if (MODE_FINAL.equals(listMode)) {
+                welcomeText.setText("Final Attendees");
+                loadFinalAttendees();
             } else {
                 welcomeText.setText(getString(R.string.waiting_list_welcome));
                 loadWaitingList();
@@ -364,6 +368,60 @@ public class UserListFragment extends Fragment {
             public void onError(Exception e) {
                 if (!isAdded()) return;
                 Toast.makeText(requireContext(), "Failed to load cancelled entrants", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void loadFinalAttendees() {
+        if (eventId == null || eventId.isEmpty()) {
+            Toast.makeText(requireContext(), "Missing event ID", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        notificationRepository.getFinalAcceptedEntrantsForEvent(eventId, new NotificationRepository.EntrantIdsCallback() {
+            @Override
+            public void onSuccess(List<String> entrantIds) {
+                if (!isAdded()) return;
+
+                List<UserListItem> items = new ArrayList<>();
+                if (entrantIds.isEmpty()) {
+                    setItems(items);
+                    return;
+                }
+
+                fetchFinalAttendeeProfilesSequentially(entrantIds, 0, items);
+            }
+
+            @Override
+            public void onError(Exception e) {
+                if (!isAdded()) return;
+                Toast.makeText(requireContext(), "Failed to load final attendees", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void fetchFinalAttendeeProfilesSequentially(List<String> entrantIds, int index, List<UserListItem> items) {
+        if (!isAdded()) return;
+
+        if (index >= entrantIds.size()) {
+            setItems(items);
+            return;
+        }
+
+        String entrantId = entrantIds.get(index);
+        profileRepository.getProfileById(entrantId, new ProfileRepository.ProfileRepositoryCallback<Profile>() {
+            @Override
+            public void onSuccess(Profile result) {
+                items.add(new UserListItem(result, "Attendance Status: Confirmed"));
+                fetchFinalAttendeeProfilesSequentially(entrantIds, index + 1, items);
+            }
+
+            @Override
+            public void onFailure(Exception exception) {
+                Profile placeholder = new Profile(entrantId, "", "", null);
+                placeholder.setUid(entrantId);
+                items.add(new UserListItem(placeholder, "Attendance Status: Confirmed"));
+                fetchFinalAttendeeProfilesSequentially(entrantIds, index + 1, items);
             }
         });
     }

--- a/app/src/main/res/layout/fragment_event_details.xml
+++ b/app/src/main/res/layout/fragment_event_details.xml
@@ -298,6 +298,26 @@
                     android:drawableEnd="@drawable/ic_chevron_right" />
 
                 <com.google.android.material.button.MaterialButton
+                    android:id="@+id/view_final_attendees_button"
+                    style="@style/Widget.Material3.Button.ElevatedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:layout_marginBottom="8dp"
+                    android:gravity="start|center_vertical"
+                    android:text="View Final Attendees"
+                    android:textAllCaps="false"
+                    android:textColor="#001541"
+                    android:textSize="15sp"
+                    app:backgroundTint="@color/white"
+                    app:cornerRadius="12dp"
+                    app:icon="@drawable/ic_calendar"
+                    app:iconPadding="12dp"
+                    app:iconSize="24dp"
+                    app:iconTint="#001541"
+                    app:rippleColor="#1F000000"
+                    android:drawableEnd="@drawable/ic_chevron_right" />
+
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/create_notification_button"
                     style="@style/Widget.Material3.Button.ElevatedButton"
                     android:layout_width="match_parent"


### PR DESCRIPTION
Features Implemented
- View invited entrants list
- View cancelled/declined entrants list

 Changes
- Added Firestore queries using NotificationRepository
- Filtered entrants based on responseStatus
- Updated UserListFragment to support multiple list modes
- Added navigation buttons in EventDetailsFragment
- Displayed invitation status in UI
